### PR TITLE
Change vue transformer version for vue2

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "@parcel/config-default",
+    "parcel-config-vue2"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
-    "@parcel/transformer-vue": "^2.5.0",
+    "parcel-config-vue2": "^0.1.3",
+    "parcel-transformer-vue2": "^0.1.7",
     "assert": "^2.0.0",
     "autoprefixer": "^9.5.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
Fix:

Currently vue transformer version is compatible with vue3 which is breaking if an external component is used. 
Updating vue transformer version compatible for vue2